### PR TITLE
Updating Unit Price and GB Conversion Calculation

### DIFF
--- a/environments/variables.tf
+++ b/environments/variables.tf
@@ -16,5 +16,5 @@ variable "law_subscription_id" {
 
 variable "costpergb" {
   description = "Data Ingestion Cost Per GB in £"
-  default     = "1.92"
+  default     = "1.15"
 }


### PR DESCRIPTION
### Jira link [(if applicable)](https://tools.hmcts.net/jira/browse/DTSPO-17324)



Updating Unit Price, we are reducing the unit price as HMCTS have a free allowance of data ingestion as HMCTS is on a legacy pricing model.

We are using 1000 instead of 1024 for converting the data representation into gigabytes. This is in line with how Microsoft calculate the data for pricing purposes. Microsoft use GB (1000) instead of 1024 (GiB).


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
